### PR TITLE
Remove obsolete snippets.m.c monitor

### DIFF
--- a/irc_channels.json
+++ b/irc_channels.json
@@ -91,10 +91,6 @@
             "channels": ["#firefoxflicks"],
             "types": ["alert", "deployment"]
         },
-        "snippets.mozilla.com": {
-            "channels": ["#snippets"],
-            "types": ["alert", "deployment"]
-        },
         "support.mozilla.org": {
             "channels": ["#sumodev"],
             "types": ["alert", "deployment"]


### PR DESCRIPTION
Snippets is part of EE deis cluster now.
